### PR TITLE
improves to speed

### DIFF
--- a/libraries/global_search.rb
+++ b/libraries/global_search.rb
@@ -4,7 +4,7 @@ require 'json'
 module SbgGlobalSearch
   module GlobalSearch 
 
-   def get_environment_nodes(env=node.chef_environment.downcase)
+   def get_environment_nodes(role, env=node.chef_environment.downcase, field_list=nil)
       real_endpoint = Chef::Config[:chef_server_url].to_s
       real_node_name = Chef::Config[:node_name].to_s
       real_client_key = Chef::Config[:client_key].to_s
@@ -50,9 +50,16 @@ module SbgGlobalSearch
             },
         }
 
+        # Adds additional fields we'd like to pull out
+        if field_list
+          field_list.each do |f|
+            args[:filter_result][f] = [ f ]
+          end
+        end
+
         # do the search using partial search
         # this incidentially implements paging for >1000 nodes
-        Chef::Search::Query.new.search( :node, "chef_environment:#{env.upcase}", args, &handler );
+        Chef::Search::Query.new.search( :node, "chef_environment:#{env.upcase} AND role:#{role}", args, &handler );
         # and sort those by fqdn
         node.run_state[attr_key].sort! { |m,n| m['name'] <=> n['name'] }
       end
@@ -66,7 +73,7 @@ module SbgGlobalSearch
     # @param [String] role the role for which we want a sorted list of members
     # @return [Array] sorted list of node objects in the current environment which belong to the searched role
     def get_role_member_list( role, env=node.chef_environment.downcase )
-        nodes = get_environment_nodes(env.downcase)
+        nodes = get_environment_nodes(role, env.downcase)
         if !nodes
           return []
         end

--- a/libraries/global_search.rb
+++ b/libraries/global_search.rb
@@ -4,7 +4,7 @@ require 'json'
 module SbgGlobalSearch
   module GlobalSearch 
 
-   def get_environment_nodes(role, env=node.chef_environment.downcase, field_list=nil)
+   def get_environment_nodes(role='*', env=node.chef_environment.downcase, field_list=nil)
       real_endpoint = Chef::Config[:chef_server_url].to_s
       real_node_name = Chef::Config[:node_name].to_s
       real_client_key = Chef::Config[:client_key].to_s

--- a/libraries/global_search.rb
+++ b/libraries/global_search.rb
@@ -4,7 +4,7 @@ require 'json'
 module SbgGlobalSearch
   module GlobalSearch 
 
-   def get_environment_nodes(role='*', env=node.chef_environment.downcase, field_list=nil)
+   def get_environment_nodes(env=node.chef_environment.downcase, role='*', field_list=nil)
       real_endpoint = Chef::Config[:chef_server_url].to_s
       real_node_name = Chef::Config[:node_name].to_s
       real_client_key = Chef::Config[:client_key].to_s
@@ -73,7 +73,7 @@ module SbgGlobalSearch
     # @param [String] role the role for which we want a sorted list of members
     # @return [Array] sorted list of node objects in the current environment which belong to the searched role
     def get_role_member_list( role, env=node.chef_environment.downcase )
-        nodes = get_environment_nodes(role, env.downcase)
+        nodes = get_environment_nodes(env.downcase, role)
         if !nodes
           return []
         end


### PR DESCRIPTION
The current Chef Query does not take advantage of the AND and filters post query. By adding the AND to the query it should be a little be faster.

Also I made a change to allow retrieving additional attributes, for example

get_environment_nodes('rolename', 'envname', ['domain'])

This will return as well as the default attrs (name, ip, etc) the domain attribute and value.
